### PR TITLE
Bug-fix - getLatestEventsForUser includes old events

### DIFF
--- a/next-app/src/repositories/event-group.ts
+++ b/next-app/src/repositories/event-group.ts
@@ -471,8 +471,12 @@ export async function getLatestEventsForUser({
   }
 
   // find the latest k events from user's groups, sorted by start date descending
+  const now = new Date();
   const events = check(
-    await Event.find({ group: { $in: groupIds } })
+    await Event.find({
+      group: { $in: groupIds },
+      "duration.endsAt": { $gte: now },
+    })
       .sort({ "duration.startsAt": -1 })
       .limit(limit)
       .lean<IEventDTO[]>(),


### PR DESCRIPTION
## 📝 Opis zmian

dodanie filtra aby brać pod uwagę tylko eventy, które się jeszcze nie skończyły

## 🧪 Jak przetestować

@joannakonieczny zobacz czy już jest ok :)
